### PR TITLE
Support VDP Rev 2 board

### DIFF
--- a/NABU-LIB.c
+++ b/NABU-LIB.c
@@ -470,7 +470,7 @@ void playNoteDelay(uint8_t channel, uint8_t note, uint16_t delayLength) {
   void vdp_waitVDPReadyInt() {
     while ((IO_JOY0 & 0x02) != 0)
       ;
-    uint8_t v = IO_VDPLATCH;
+    vdpStatusRegVal = IO_VDPLATCH;
   }
   
   void waitVdpISR() {

--- a/NABU-LIB.c
+++ b/NABU-LIB.c
@@ -468,9 +468,11 @@ void playNoteDelay(uint8_t channel, uint8_t note, uint16_t delayLength) {
   }
 
   void vdp_waitVDPReadyInt() {
-    while ((IO_VDPLATCH & 0x80) == 0)
+    while ((IO_JOY0 & 0x02) != 0)
       ;
+    uint8_t v = IO_VDPLATCH;
   }
+  
   void waitVdpISR() {
     ;
   }


### PR DESCRIPTION
Updates the library to support the Rev2 board.

Rev 1 board owners must either bodge U6 Pin4 to U2 Pin16 or run a jumper from Pin1 on J6 to Pin5 on J5.

This update will break compatibility an un-patched REV 1 board.